### PR TITLE
CD-116190 Modify paperclip-azure to use 'azure-storage-blob' gem instead of 'azure-storage (preview)'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Hoe.spec "paperclip-azure" do
   license "MIT" # this should match the license in the README
 
   extra_deps << ['azure', '~> 0.7']
-  extra_deps << ['azure-storage', '~> 0.12']
+  extra_deps << ['azure-storage-blob', '~> 1.0.1']
   extra_deps << ['hashie', '~> 3.5']
   extra_deps << ['addressable', '~> 2.5']
 

--- a/paperclip-azure.gemspec
+++ b/paperclip-azure.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<azure>.freeze, ["~> 0.7"])
-      s.add_runtime_dependency(%q<azure-storage>.freeze, ["~> 0.12"])
+      s.add_runtime_dependency(%q<azure-storage-blob>.freeze, ["~> 1.0.1"])
       s.add_runtime_dependency(%q<hashie>.freeze, ["~> 3.5"])
       s.add_runtime_dependency(%q<addressable>.freeze, ["~> 2.5"])
       s.add_development_dependency(%q<paperclip>.freeze, [">= 4.3.6"])
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<hoe>.freeze, ["~> 3.16"])
     else
       s.add_dependency(%q<azure>.freeze, ["~> 0.7"])
-      s.add_dependency(%q<azure-storage>.freeze, ["~> 0.12"])
+      s.add_dependency(%q<azure-storage-blob>.freeze, ["~> 1.0.1"])
       s.add_dependency(%q<hashie>.freeze, ["~> 3.5"])
       s.add_dependency(%q<addressable>.freeze, ["~> 2.5"])
       s.add_dependency(%q<paperclip>.freeze, [">= 4.3.6"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<azure>.freeze, ["~> 0.7"])
-    s.add_dependency(%q<azure-storage>.freeze, ["~> 0.12"])
+    s.add_dependency(%q<azure-storage-blob>.freeze, ["~> 1.0.1"])
     s.add_dependency(%q<hashie>.freeze, ["~> 3.5"])
     s.add_dependency(%q<addressable>.freeze, ["~> 2.5"])
     s.add_dependency(%q<paperclip>.freeze, [">= 4.3.6"])

--- a/spec/paperclip/storage/azure_spec.rb
+++ b/spec/paperclip/storage/azure_spec.rb
@@ -245,8 +245,8 @@ describe Paperclip::Storage::Azure do
         @dummy.avatar = stringy_file
       end
 
-      allow(::Azure::Storage::Core::Auth::SharedAccessSignature).to receive(:new).and_call_original
-      allow(::Azure::Storage::Core::Auth::SharedAccessSignatureSigner).to receive(:new).and_call_original
+      allow(::Azure::Storage::Common::Core::Auth::SharedAccessSignature).to receive(:new).and_call_original
+      allow(::Azure::Storage::Common::Core::Auth::SharedAccessSignatureSigner).to receive(:new).and_call_original
     end
 
     it "generates a url for the thumb" do
@@ -254,7 +254,7 @@ describe Paperclip::Storage::Azure do
         expect { @dummy.avatar.expiring_url(1800, :thumb) }.not_to raise_error
       end
 
-      expect(::Azure::Storage::Core::Auth::SharedAccessSignature).to have_received(:new)
+      expect(::Azure::Storage::Common::Core::Auth::SharedAccessSignature).to have_received(:new)
         .with('prod_storage', anything)
     end
 
@@ -263,7 +263,7 @@ describe Paperclip::Storage::Azure do
         expect { @dummy.avatar.expiring_url(1800) }.not_to raise_error
       end
 
-      expect(::Azure::Storage::Core::Auth::SharedAccessSignature).to have_received(:new)
+      expect(::Azure::Storage::Common::Core::Auth::SharedAccessSignature).to have_received(:new)
         .with('prod_storage', anything)
     end
   end


### PR DESCRIPTION
## JIRA 

- [Main Ticket](https://coupadev.atlassian.net/browse/CD-116190)
- [Propagation Ticket](https://coupadev.atlassian.net/browse/CD-116193)

## Reviewers
-  [ ] @tjackiw 

## Summary of change

`paperclip-azure` gem currently uses `azure-storage ~> (0.12)`.  The latest version of the `azure-storage` gem 1.0.1 is released and it has specific gems for `blobs`, `tables`, `pages` etc.  Since paperclip internally uses blob storage, using the `azure-storage-blob` gem.