### PR TITLE
CD-117314 Change the exponential retry policy for azure api calls to use smaller retries

### DIFF
--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -146,7 +146,9 @@ module Paperclip
         return instances[options] if instances[options]
 
         service = ::Azure::Storage::Blob::BlobService.new(client: azure_storage_client)
-        service.with_filter ::Azure::Storage::Common::Core::Filter::ExponentialRetryPolicyFilter.new
+        # LinearRetryPolicy throws some argument error. Have raised an issue in azure-storage-ruby repo - https://github.com/Azure/azure-storage-ruby/issues/121
+        # Till then using exponential retry filter with smaller retry values
+        service.with_filter ::Azure::Storage::Common::Core::Filter::ExponentialRetryPolicyFilter.new(2, 10, 20)
 
         instances[options] = service
       end


### PR DESCRIPTION
## Code Reviewers

- [x] @tjackiw 

## Summary of issue
`paperclip-azure` gem by default retries when there are any failures with respect to Azure Blob API call. It is associated to a ExponentialRetryPolicy without any specific retry counts. In other words, it uses the default retry values of the azure-storage-common gem. The default retry values and [retry intervals are too high](https://github.com/Azure/azure-storage-ruby/blob/master/common/lib/azure/storage/common/core/filter/exponential_retry_filter.rb#L42-#L44) that we need to wait for more than 3mins for the result.

Lets take an example. `azure-storage-blob` returns 'AzureHttpError` when the blob is not present. Since paperclip uses the default exponential retries, we have to wait for a long time to know if the paperclip's azure object exists or not.

## Summary of Change
 Changing to small retry values so that it does not have any major impact on coupa-enterprise waiting so long for retries


**Note:** We can make use of [LinearRetryFilter](https://github.com/Azure/azure-storage-ruby/blob/master/common/lib/azure/storage/common/core/filter/linear_retry_filter.rb). But there seems to be an issue when we use LinearRetryFilter. Have [raised an issue in the upstream repo](https://github.com/Azure/azure-storage-ruby/issues/121) as well but the author told that it will be fixed in the next release only. If that is fixed, then we can use LinearRetryFilter. Till then lets use ExponentialRetry with smaller retry values or intervals

@sushmanivargi - FYI