### PR TITLE
CD-122162 Remove the retry Exponential filter for azure api calls in paperclip-azure gem

### DIFF
--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -148,7 +148,8 @@ module Paperclip
         service = ::Azure::Storage::Blob::BlobService.new(client: azure_storage_client)
         # LinearRetryPolicy throws some argument error. Have raised an issue in azure-storage-ruby repo - https://github.com/Azure/azure-storage-ruby/issues/121
         # Till then using exponential retry filter with smaller retry values
-        service.with_filter ::Azure::Storage::Common::Core::Filter::ExponentialRetryPolicyFilter.new(2, 10, 20)
+        # Commenting out the retry filter as we see issues with ExponentialRetryPolicyFilter as well
+        # service.with_filter ::Azure::Storage::Common::Core::Filter::ExponentialRetryPolicyFilter.new(2, 10, 20)
 
         instances[options] = service
       end


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CD-122162)

## Code Reviewers

- [ ] @tjackiw 

## Summary of Issue

Jenkins master is failing because of the following error.

```
time interval must be positive
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-storage-common-1.0.1/lib/azure/storage/common/core/filter/retry_filter.rb:152:in `sleep'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-storage-common-1.0.1/lib/azure/storage/common/core/filter/retry_filter.rb:152:in `wait_for_retry'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-storage-common-1.0.1/lib/azure/storage/common/core/filter/retry_filter.rb:70:in `should_retry?'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/http/retry_policy.rb:51:in `call'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/http/http_request.rb:110:in `block in with_filter'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/http/signer_filter.rb:28:in `call'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/http/signer_filter.rb:28:in `call'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/http/http_request.rb:110:in `block in with_filter'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/service.rb:36:in `call'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/filtered_service.rb:34:in `call'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-core-0.1.14/lib/azure/core/signed_service.rb:41:in `call'
/home/jenkins/.rvm/gems/ruby-2.5.1/gems/azure-storage-common-1.0.1/lib/azure/storage/common/service/storage_service.rb:60:in `call'
{code}
```

## Summary of change

- Looks like there are some issues with http requests call made from jenkins to access azure. And because of the request failure, it retries and there are some issues with respect to retry filters in [azure-storage-common ](https://github.com/Azure/azure-storage-ruby/blob/master/common/lib/azure/storage/common/core/filter/retry_filter.rb#L151)gem.

**Note:** We had the same error trace in LinearRetryPolicy and the [issue has been raised](https://github.com/Azure/azure-storage-ruby/issues/121) in the repo. The author mentioned that it will be fixed in the later release. Now the issue is happening in Exponential Retries as well.

-  Comment out the retry policy associated to azure api calls in paperclip-azure gem so that we know the reason for the https failure in future if it happens. 

**Note: We need to figure out why http calls to azure are failing in jenkins first. Fixing this won't fix the jenkins failure in master. But as of now, we are not able to reproduce the issue locally. Hence commenting out the retry policy, to see the trace/error message with respect to the http request failure**