### PR TITLE
Added support for storage Shared Access Signature(SAS) tokens

### DIFF
--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -134,16 +134,16 @@ module Paperclip
       end
 
       def set_access_config(config)
-        [:storage_account_name, :storage_access_key, :container].each do |opt|
+        [:storage_account_name, :storage_access_key, :storage_sas_token, :container].each do |opt|
           config[opt] = azure_credentials[opt] if azure_credentials[opt]
-        end 
+        end
         config
       end
 
       def azure_storage_client
         config = {}
 
-        [:storage_account_name, :storage_access_key].each do |opt|
+        [:storage_account_name, :storage_access_key, :storage_sas_token].each do |opt|
           config[opt] = azure_credentials[opt] if azure_credentials[opt]
         end
 
@@ -211,10 +211,9 @@ module Paperclip
               content_type: file.content_type,
             }
 
-            if azure_container
-              save_blob container_name, path(style).sub(%r{\A/},''), file, write_options
-            end
+            save_blob container_name, path(style).sub(%r{\A/},''), file, write_options
           rescue ::Azure::Core::Http::HTTPError => e
+            # TODO: Determine how to handle failures when the container doesn't exist and an access key or account SAS token is used
             if e.status_code == 404
               create_container
               retry

--- a/spec/paperclip/storage/azure_spec.rb
+++ b/spec/paperclip/storage/azure_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require "base64"
 
 describe Paperclip::Storage::Azure do
+  let(:config) { { storage_account_name: 'test', storage_sas_token: 'testing' } }
   let(:storage_access_key) { 'kiaY4+GkLMVxnfOK2X+eCJOE06J8QtHC6XNuXVwt8Pp4kMezYaa7cNjtYnZr4/b732RKdz5pZwl8RN9yb8gBCg==' }
 
   describe "#parse_credentials" do
@@ -37,6 +38,32 @@ describe Paperclip::Storage::Azure do
       end
     end
 
+  end
+
+  describe "#set_access_config" do
+    let(:dummy) { Dummy.new }
+
+    subject { dummy.avatar.set_access_config(config) }
+
+    it "accepts storage SAS tokens" do
+      expect(subject).to include(:storage_sas_token)
+      expect(subject[:storage_sas_token]).to include('testing')
+    end
+  end
+
+  describe "#azure_storage_client" do
+    before do
+      rebuild_model storage: :azure,
+                    azure_credentials: config
+      @dummy = Dummy.new
+    end
+
+    subject { @dummy.avatar.azure_storage_client.options }
+
+    it "accepts storage SAS tokens" do
+      expect(subject).to include(:storage_sas_token)
+      expect(subject[:storage_sas_token]).to include('testing')
+    end
   end
 
   describe '#container_name' do


### PR DESCRIPTION
- Removed checking for the existence of the container prior to saving the blob.
  The S3 adapter doesn't check to see if the bucket exists, I'm not sure why
  this adapter was written to do this. Normally, we assume that the storage
  bucket/container already exists and create/raise errors accordingly.
  Service SAS tokens can't do container operations, only Account SAS tokens can.
  However, if you're trying to partition access to containers, you'll want to
  use a Service SAS token because an Account SAS token can access across
  containers. Because this commit adds support for SAS tokens, and because the
  original S3 adapter didn't bother with checking if a bucket existed first, I'm
  removing the container existence check.
- We'll want to re-add support for container operations when access keys or account
  SAS tokens are used. However, given that we're not concerned with that usecase
  at this time, we will re-implement that functionality at another date.
- CD-126987

Please review:
- [x] @johnny-lai 
- [ ] @revathi-murali 