### PR TITLE
JZ-69885 Use azure interface without retry when downloading attachments

### DIFF
--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -265,7 +265,7 @@ module Paperclip
       def copy_to_local_file(style, local_dest_path)
         log("copying #{path(style)} to local file #{local_dest_path}")
 
-        _, content = azure_interface.get_blob(container_name, path(style).sub(%r{\A/},''))
+        _, content = azure_interface_without_retry.get_blob(container_name, path(style).sub(%r{\A/},''))
 
         ::File.open(local_dest_path, 'wb') do |local_file|
           local_file.write(content)


### PR DESCRIPTION
## Reviewers

- [x] @abdulchaudhrycoupa 

## Summary of change

When attachment does not exist, 404 is raised which in turn is retried twice based on the retry policy. This in turn increases the page load. Hence using azure interface without retry when downloading attachments.

## Generated Reviewers

<details>
  <summary><em>:warning: Do not modify anything in this section! :warning:</em></summary>
  <em>The content in this section is managed automatically, and any manual changes to it will be ignored and overwritten the next time the code review status is refreshed! View <a href="https://cody.coupa.engineering/repos/coupa/paperclip-azure/pull/7">this PR</a> on Cody to see the current code review status.</em>
</details>

